### PR TITLE
mvnとmvnwの違い

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 ## SpringBootAPIの使い方手順
-1. git cloneでクローンしてください。
+1. リポジトリをクローンしてください。
+   ```
+   git clone https://github.com/ZarLiHninn/SpringBootAPI.git
+   ```
 2. UserData-dbのファイルをmysqlにインポートしてください。
-3. mvn installで実行してください。
-4. java -jar ec2demo0.0.1-SNAPSHOT.jarを実行してください。
-5. localhost:8080/userListで実行してください。
-6. 以下のようなデーターが表示されたらokです。
+3. 以下のコマンドで実行してください。
+   ```
+   ./mvnw spring-boot:run
+   ```
+4. localhost:8080/usersで実行してください。
+5. 以下のようなデーターが表示されたらokです。
 
 ![alt text for screen readers](https://github.com/ZarLiHninn/SpringBootAPI/blob/main/images/Screen%20Shot%202022-02-25%20at%203.43.44%20PM.png "user lists")

--- a/README.md
+++ b/README.md
@@ -10,5 +10,4 @@
    ```
 4. localhost:8080/usersで実行してください。
 5. 以下のようなデーターが表示されたらokです。
-
-![alt text for screen readers](https://github.com/ZarLiHninn/SpringBootAPI/blob/main/images/Screen%20Shot%202022-02-25%20at%203.43.44%20PM.png "user lists")
+<img width="345" alt="Screen Shot 2022-03-04 at 11 41 50 PM" src="https://user-images.githubusercontent.com/61935228/156815806-1e52600e-5bf8-4495-99d7-edf33ac67f5e.png">


### PR DESCRIPTION
## mvnとmvnwの違いの勉強
自分のSpring Bootプロジェクトをコマンドで実行したい場合は、以下の二つのコマンドが使えます。
1. mvnコマンド
2. mnnwコマンド

### mvnコマンド
- mvnで実行したい場合は、自分のプロジェクトのjarファイルをもらうために、以下のコマンドを実行しないといけないです
```
 mvn install
```
- jarファイルがもらったら、jarファイルがある場所まで行って自分のファイル名で以下のように実行する必要があります。
```
java -jar ./target/ec2demo0.0.1-SNAPSHOT.jar
 ```

### mvnwコマンド
- mvnwで実行したい場合は、たくさんのステップが必要なく、以下の一つのコマンドだけで必要なmavenファイルやwrapperファイルやjarファイルなどまで自動的にインストールされて実行できます。
```
./mvnw spring-boot:run
```
## mvnからmvnwのコマンドへ変えた理由
mvnコマンドを使うと必要なmavenファイルをインストールする時間とjarファイルがあるところまで行って実行する必要があります。
その一方で、mvnwは一つのコマンドだけ必要ですし、実行する時間も秒分だけですので選びました。

以下のリンクを参考にしました。
https://www.baeldung.com/maven-wrapper
